### PR TITLE
added case sensitivity as a property for wildcard

### DIFF
--- a/src/types/queries.ts
+++ b/src/types/queries.ts
@@ -275,10 +275,12 @@ export interface WildcardFieldConfig {
     | {
         value: string
         boost?: number
+        case_insensitive?: boolean
       }
     | {
         wildcard: string
         boost?: number
+        case_insensitive?: boolean
       }
 }
 export interface WildcardQuery {


### PR DESCRIPTION
In my project I'm using elasticSearch and this package for types. I really need to add this type - it's basic property for wildcard queries that allow us to choose if we want to have it case insensitive. It's case sensitive by default.