### PR TITLE
chore: Support for extended_bounds in Date Histogram Aggregation for elastic-ts

### DIFF
--- a/src/types/aggregations.ts
+++ b/src/types/aggregations.ts
@@ -191,6 +191,10 @@ export interface DateHistogramAggregation {
     fixed_interval?: string
     offset?: string
     min_doc_count?: number
+    extended_bounds?: {
+      min: number | string
+      max: number | string
+    }
     format?: string
     time_zone?: string
     keyed?: boolean

--- a/test/aggregations.spec.ts
+++ b/test/aggregations.spec.ts
@@ -284,6 +284,44 @@ describe('esBuilder - Aggregations', () => {
     })
   })
 
+  it('date_histogram aggregation with extended_bounds support', () => {
+    const result = esBuilder().aggregation('agg_date_histogram_extended_bounds',
+      'date_histogram', 'extended', { extended_bounds: {min: 0, max: 1} }).build()
+
+    expect(result).toEqual({
+      aggs: {
+        agg_date_histogram_extended_bounds: {
+          date_histogram: {
+            field: 'extended',
+            extended_bounds: {
+              max: 1,
+              min: 0
+            }
+          },
+        },
+      },
+    })
+  })
+
+  it('date_histogram aggregation with extended_bounds support, date string format', () => {
+    const result = esBuilder().aggregation('agg_date_histogram_extended_bounds',
+      'date_histogram', 'extended', { extended_bounds: {min: '2024-01-01', max: '2024-12-31'} }).build()
+
+    expect(result).toEqual({
+      aggs: {
+        agg_date_histogram_extended_bounds: {
+          date_histogram: {
+            field: 'extended',
+            extended_bounds: {
+              max: '2024-12-31',
+              min: '2024-01-01'
+            }
+          },
+        },
+      },
+    })
+  })
+
   it('date_range aggregation', () => {
     const result = esBuilder()
       .aggregation('agg_date_range_date', 'date_range', 'date', {


### PR DESCRIPTION
Modified the Date histogram aggregation by adding support for extended_bounds. The type for min and max in extended_bounds is now a union type of number | string, accommodating both Date string formats and numeric timestamps.